### PR TITLE
Add compatibility wrapper for setweighting to handle the `fracbw` abs…

### DIFF
--- a/src/pclean/imaging/serial_imager.py
+++ b/src/pclean/imaging/serial_imager.py
@@ -371,7 +371,10 @@ class SerialImager:
             'fracbw',
         }
         wp = {k: v for k, v in self._weightpars.items() if k in _WEIGHT_KEYS}
-        self.si_tool.setweighting(**wp)
+
+        from pclean.parallel.worker_tasks import _safe_setweighting
+
+        _safe_setweighting(self.si_tool, wp)
 
     def _init_iteration_control(self) -> None:
         ct = _ct()

--- a/src/pclean/parallel/worker_tasks.py
+++ b/src/pclean/parallel/worker_tasks.py
@@ -22,6 +22,50 @@ log = logging.getLogger(__name__)
 
 
 # ======================================================================
+# setweighting compatibility wrapper
+# ======================================================================
+
+
+def _safe_setweighting(si, wp: dict) -> None:
+    """Call ``si.setweighting(**wp)`` with a fallback for unpatched casatools.
+
+    If *wp* contains ``fracbw`` and the installed ``casatools`` does not
+    support it (i.e. the ``CAS-14520`` patch has not been applied),
+    the call will raise ``TypeError: unexpected keyword argument
+    'fracbw'``.  In that case we:
+
+    1. Drop the ``fracbw`` key.
+    2. If ``rmode == 'bwtaper'`` (briggsbwtaper), downgrade to
+       ``rmode='norm'`` (standard Briggs) so the C++ layer does not
+       receive an unrecognised mode string.
+    3. Log a warning so the user knows the weighting has been degraded.
+
+    This keeps pclean functional with *any* casatools build while still
+    using the optimal weighting when the patch is present.
+    """
+    try:
+        si.setweighting(**wp)
+    except TypeError as exc:
+        if 'fracbw' not in str(exc):
+            raise
+        wp = dict(wp)  # don't mutate caller's dict
+        wp.pop('fracbw', None)
+        if wp.get('rmode') == 'bwtaper':
+            wp['rmode'] = 'norm'
+            log.warning(
+                'casatools does not support the fracbw parameter '
+                '(CAS-14520 patch not applied) — falling back from '
+                'briggsbwtaper to standard briggs weighting',
+            )
+        else:
+            log.warning(
+                'casatools does not support the fracbw parameter '
+                '(CAS-14520 patch not applied) — dropping fracbw',
+            )
+        si.setweighting(**wp)
+
+
+# ======================================================================
 # Table cache helpers
 # ======================================================================
 
@@ -169,7 +213,7 @@ def make_partial_psf(bundle: dict) -> str:
     si = ct.synthesisimager()
     try:
         _select_and_define(si, bundle)
-        si.setweighting(**bundle['weightpars'])
+        _safe_setweighting(si, bundle['weightpars'])
         si.makepsf()
     finally:
         si.done()
@@ -194,7 +238,7 @@ def run_partial_major_cycle(
     si = ct.synthesisimager()
     try:
         _select_and_define(si, bundle)
-        si.setweighting(**bundle['weightpars'])
+        _safe_setweighting(si, bundle['weightpars'])
         si.executemajorcycle(controls=controls or {})
     finally:
         si.done()
@@ -248,7 +292,7 @@ class _WorkerGridder:
         self._imagename: str = bundle['allimpars']['0']['imagename']
         self.si = ct.synthesisimager()
         _select_and_define(self.si, bundle)
-        self.si.setweighting(**bundle['weightpars'])
+        _safe_setweighting(self.si, bundle['weightpars'])
 
     def make_psf(self) -> str:
         self.si.makepsf()


### PR DESCRIPTION
This pull request improves compatibility with different versions of `casatools` by introducing a wrapper function for setting imaging weights. The main change is the addition of a robust `_safe_setweighting` function, which gracefully handles cases where the `fracbw` parameter is not supported, ensuring that the code works with both patched and unpatched versions of `casatools`. Several calls to `setweighting` are updated to use this new wrapper.

**Compatibility improvements for casatools weighting:**

* Added the `_safe_setweighting` function in `worker_tasks.py` to handle cases where the `fracbw` parameter is not supported by the installed `casatools` (CAS-14520 patch not applied). This function downgrades the weighting mode and logs a warning if necessary.
* Updated all calls to `setweighting` in `serial_imager.py` and `worker_tasks.py` to use `_safe_setweighting`, ensuring robust behavior across different `casatools` versions. [[1]](diffhunk://#diff-29e0bde5677fb6c87626417772b585de240446beb76417594b4c747a63301297L374-R377) [[2]](diffhunk://#diff-d53a529eec86cbc9e4e7cdc90fdfea00aa87136c4b1e45d5e597b8818314b22eL172-R216) [[3]](diffhunk://#diff-d53a529eec86cbc9e4e7cdc90fdfea00aa87136c4b1e45d5e597b8818314b22eL197-R241) [[4]](diffhunk://#diff-d53a529eec86cbc9e4e7cdc90fdfea00aa87136c4b1e45d5e597b8818314b22eL251-R295)…ence in unpatched `casatools` python APIs.

Note: to get the full `briggbwtaper` functionality, one either manually applies the pending CAS-14520 patch and rebuilds casatools from scratch, or uses the patched `casatools` builds from the personal Anaconda channel (https://anaconda.org/channels/rxue/packages/casatools/overview)