### PR TITLE
Improve `ImageConfig` and `PcleanConfig` to support mixed types for s…

### DIFF
--- a/src/pclean/config.py
+++ b/src/pclean/config.py
@@ -68,8 +68,8 @@ class ImageConfig(BaseModel):
     specmode: str = 'mfs'
     reffreq: str = ''
     nchan: int = -1
-    start: str = ''
-    width: str = ''
+    start: str | int = ''
+    width: str | int = ''
     outframe: str = 'LSRK'
     veltype: str = 'radio'
     restfreq: list[str] = Field(default_factory=list)
@@ -812,6 +812,7 @@ class PcleanConfig(BaseModel):
         start: int | str,
         nchan: int,
         image_suffix: str,
+        width: int | str | None = None,
     ) -> PcleanConfig:
         """Return a copy tuned for a channel sub-range (cube parallelism).
 
@@ -819,10 +820,16 @@ class PcleanConfig(BaseModel):
             start: Start channel (int) or frequency/velocity string.
             nchan: Number of channels in this subcube.
             image_suffix: Suffix appended to the base imagename.
+            width: Channel width override.  When *start* is converted
+                to a frequency string the caller must also supply a
+                matching frequency *width* so that CASA does not
+                reject mixed unit types.
         """
         data = self.model_dump(mode='python')
         data['image']['nchan'] = nchan
         data['image']['start'] = start if isinstance(start, str) else str(start)
+        if width is not None:
+            data['image']['width'] = width if isinstance(width, str) else str(width)
         data['image']['imagename'] = f'{self.imagename}.subcube.{image_suffix}'
         # Pre-compute fracbw from the *parent* (full-cube) config so that
         # subcubes with nchan=1 still get the correct fractional bandwidth

--- a/src/pclean/utils/partition.py
+++ b/src/pclean/utils/partition.py
@@ -373,10 +373,53 @@ def _partition_cube_even(
     if start_hz is not None and width_hz is not None and nchan > 1:
         resolved_freqs = _resolve_frequency_grid(config, nchan)
 
+    # For briggsbwtaper: pre-compute fracbw from the *full* cube so that
+    # single-channel subcubes inherit a valid fractional bandwidth.
+    # Without this, nchan=1 subcubes get fracbw=0 and CASA's
+    # BriggsCubeWeightor rejects the value.
+    if (
+        config.weight.weighting == 'briggsbwtaper'
+        and config.weight.fracbw is None
+        and nchan > 1
+    ):
+        if resolved_freqs is not None and len(resolved_freqs) >= 2:
+            min_f = min(resolved_freqs)
+            max_f = max(resolved_freqs)
+            config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
+        elif start_hz is not None and width_hz is not None:
+            min_f = start_hz
+            max_f = start_hz + (nchan - 1) * abs(width_hz)
+            if min_f > max_f:
+                min_f, max_f = max_f, min_f
+            config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
+        else:
+            # Integer start/width: resolve frequency grid to get fracbw.
+            freqs = _resolve_frequency_grid(config, nchan)
+            if freqs is not None and len(freqs) >= 2:
+                min_f = min(freqs)
+                max_f = max(freqs)
+                config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
+                resolved_freqs = freqs  # reuse for partition below
+        if config.weight.fracbw is not None:
+            log.info(
+                'Pre-computed fracbw=%.6g for briggsbwtaper from full cube',
+                config.weight.fracbw,
+            )
+
     # Greedy distribution: first (nchan % nparts) subcubes get one
     # extra channel, matching CASA's C++ cubedataimagepartition.
     chans_per_base = nchan // nparts
     remainder = nchan % nparts
+
+    # Compute the frequency-domain channel width so that subcubes whose
+    # ``start`` is a frequency string also carry a matching ``width``.
+    # Without this, CASA rejects the mixed unit types (e.g. start in
+    # GHz but width as a bare channel count).
+    freq_width: str | None = None
+    if resolved_freqs is not None and len(resolved_freqs) >= 2:
+        freq_width = _format_freq_ghz(resolved_freqs[1] - resolved_freqs[0])
+    elif start_hz is not None and width_hz is not None:
+        freq_width = _format_freq_ghz(width_hz)
 
     result: list[PcleanConfig] = []
     chan_offset = 0
@@ -388,14 +431,17 @@ def _partition_cube_even(
         if resolved_freqs is not None:
             # Use the exact frequency from the resolved grid.
             sub_start = _format_freq_ghz(resolved_freqs[chan_offset])
+            sub_width = freq_width
         elif start_hz is not None and width_hz is not None:
             sub_start_hz = start_hz + chan_offset * width_hz
             sub_start = _format_freq_ghz(sub_start_hz)
+            sub_width = freq_width
         else:
             sub_start = str(chan_offset)
+            sub_width = None
 
         log.info('  subcube %d: start=%s  nchan=%d  (chan_offset=%d)', i, sub_start, nc, chan_offset)
-        sub = config.make_subcube_config(sub_start, nc, str(i))
+        sub = config.make_subcube_config(sub_start, nc, str(i), width=sub_width)
         result.append(sub)
         chan_offset += nc
 

--- a/src/pclean/utils/partition.py
+++ b/src/pclean/utils/partition.py
@@ -392,13 +392,14 @@ def _partition_cube_even(
             max_f = max(start_hz, end_f)
             config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
         else:
-            # Integer start/width: resolve frequency grid to get fracbw.
+            # Integer start/width: resolve frequency grid to get fracbw only.
+            # Do not assign to resolved_freqs — the user asked for channel-based
+            # partitioning, so subcube starts should remain channel indices.
             freqs = _resolve_frequency_grid(config, nchan)
             if freqs is not None and len(freqs) >= 2:
                 min_f = min(freqs)
                 max_f = max(freqs)
                 config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
-                resolved_freqs = freqs  # reuse for partition below
         if config.weight.fracbw is not None:
             log.info(
                 'Pre-computed fracbw=%.6g for briggsbwtaper from full cube',

--- a/src/pclean/utils/partition.py
+++ b/src/pclean/utils/partition.py
@@ -387,10 +387,9 @@ def _partition_cube_even(
             max_f = max(resolved_freqs)
             config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
         elif start_hz is not None and width_hz is not None:
-            min_f = start_hz
-            max_f = start_hz + (nchan - 1) * abs(width_hz)
-            if min_f > max_f:
-                min_f, max_f = max_f, min_f
+            end_f = start_hz + (nchan - 1) * width_hz
+            min_f = min(start_hz, end_f)
+            max_f = max(start_hz, end_f)
             config.weight.fracbw = 2.0 * (max_f - min_f) / (max_f + min_f)
         else:
             # Integer start/width: resolve frequency grid to get fracbw.
@@ -440,7 +439,13 @@ def _partition_cube_even(
             sub_start = str(chan_offset)
             sub_width = None
 
-        log.info('  subcube %d: start=%s  nchan=%d  (chan_offset=%d)', i, sub_start, nc, chan_offset)
+        log.info(
+            '  subcube %d: start=%s  nchan=%d  (chan_offset=%d)',
+            i,
+            sub_start,
+            nc,
+            chan_offset,
+        )
         sub = config.make_subcube_config(sub_start, nc, str(i), width=sub_width)
         result.append(sub)
         chan_offset += nc

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -399,3 +399,203 @@ class TestResolveConcatMode:
         mode, _ = self._resolve('supersonic', False)
         assert mode == 'paged'
 
+
+class TestFreqWidthPropagation:
+    """Frequency-based partitions must give subcubes a frequency width, not a channel count."""
+
+    def test_freq_subcubes_have_freq_width(self):
+        """When start/width are frequency strings, every subcube.image.width
+        should be a frequency quantity (e.g. ending in 'GHz'), not a bare
+        channel count like '1'."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=40,
+            start='214.4501854310GHz',
+            width='15.6245970MHz',
+        )
+        subs = _partition_cube_even(cfg, nparts=8, nchan=40)
+        for sub in subs:
+            assert sub.image.width is not None
+            assert 'GHz' in sub.image.width or 'MHz' in sub.image.width, (
+                f'subcube width should be a frequency quantity, got {sub.image.width!r}'
+            )
+
+    def test_freq_width_consistent_across_subcubes(self):
+        """All subcubes should carry the same frequency width."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=20,
+            start='268.5GHz',
+            width='0.2441382MHz',
+        )
+        subs = _partition_cube_even(cfg, nparts=5, nchan=20)
+        widths = {s.image.width for s in subs}
+        assert len(widths) == 1, f'all subcubes should share the same width, got {widths}'
+
+    def test_single_chan_subcube_has_freq_width(self):
+        """chunksize=1 → nchan=1 subcubes must still get a frequency width."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=4,
+            start='268.5GHz',
+            width='0.2441382MHz',
+        )
+        subs = _partition_cube_even(cfg, nparts=4, nchan=4)
+        assert len(subs) == 4
+        for sub in subs:
+            assert sub.image.nchan == 1
+            assert 'GHz' in sub.image.width or 'MHz' in sub.image.width
+
+    def test_channel_start_keeps_channel_width(self):
+        """When start is a channel index, width should remain channel-based."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=20,
+            start='0',
+            width='1',
+        )
+        subs = _partition_cube_even(cfg, nparts=4, nchan=20)
+        for sub in subs:
+            # Channel-based start → width should NOT be a frequency string
+            assert 'GHz' not in (sub.image.width or '')
+
+
+class TestBriggsBwtaperFracbw:
+    """briggsbwtaper partitions with nchan=1 subcubes must produce a positive fracbw."""
+
+    def test_fracbw_precomputed_on_parent(self):
+        """_partition_cube_even should set config.weight.fracbw before
+        creating subcubes so that nchan=1 children inherit it."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=10,
+            start='268.5GHz',
+            width='0.2441382MHz',
+            weighting='briggsbwtaper',
+            robust=0.5,
+        )
+        assert cfg.weight.fracbw is None  # not set yet
+        _partition_cube_even(cfg, nparts=10, nchan=10)
+        # After partitioning, parent config should have fracbw populated
+        assert cfg.weight.fracbw is not None
+        assert cfg.weight.fracbw > 0
+
+    def test_single_chan_subcube_has_positive_fracbw(self):
+        """nchan=1 subcubes with briggsbwtaper must have fracbw > 0 in
+        to_casa_weightpars(), not the zero that nchan=1 alone would produce."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=10,
+            start='268.5GHz',
+            width='0.2441382MHz',
+            weighting='briggsbwtaper',
+            robust=0.5,
+        )
+        subs = _partition_cube_even(cfg, nparts=10, nchan=10)
+        for sub in subs:
+            assert sub.image.nchan == 1
+            wp = sub.to_casa_weightpars()
+            assert 'fracbw' in wp, 'weightpars must contain fracbw'
+            assert wp['fracbw'] > 0, f'fracbw must be positive, got {wp["fracbw"]}'
+
+    def test_fracbw_value_is_reasonable(self):
+        """fracbw should be consistent with 2*(fmax-fmin)/(fmax+fmin)
+        computed from the full cube frequency span."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        nchan = 20
+        start_ghz = 268.5
+        width_mhz = 0.2441382
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=nchan,
+            start=f'{start_ghz}GHz',
+            width=f'{width_mhz}MHz',
+            weighting='briggsbwtaper',
+            robust=0.5,
+        )
+        subs = _partition_cube_even(cfg, nparts=nchan, nchan=nchan)
+        fracbw = subs[0].to_casa_weightpars()['fracbw']
+
+        # Expected: 2*(fmax - fmin)/(fmax + fmin) from the *full* cube
+        fmin = start_ghz * 1e9
+        fmax = fmin + (nchan - 1) * width_mhz * 1e6
+        expected = 2.0 * (fmax - fmin) / (fmax + fmin)
+        assert abs(fracbw - expected) / expected < 1e-4, (
+            f'fracbw={fracbw} differs from expected={expected}'
+        )
+
+    def test_all_subcubes_share_same_fracbw(self):
+        """Every subcube in a briggsbwtaper partition should get the same fracbw."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=12,
+            start='268.5GHz',
+            width='0.2441382MHz',
+            weighting='briggsbwtaper',
+            robust=0.5,
+        )
+        subs = _partition_cube_even(cfg, nparts=4, nchan=12)
+        fracbws = [s.to_casa_weightpars()['fracbw'] for s in subs]
+        assert all(f == fracbws[0] for f in fracbws), (
+            f'all subcubes must share the same fracbw, got {fracbws}'
+        )
+
+    def test_non_briggsbwtaper_no_fracbw(self):
+        """Non-briggsbwtaper weighting should not produce a fracbw key."""
+        from pclean.config import PcleanConfig
+        from pclean.utils.partition import _partition_cube_even
+
+        cfg = PcleanConfig.from_flat_kwargs(
+            vis='a.ms',
+            imagename='cube',
+            specmode='cube',
+            nchan=10,
+            start='268.5GHz',
+            width='0.2441382MHz',
+            weighting='briggs',
+            robust=0.5,
+        )
+        subs = _partition_cube_even(cfg, nparts=10, nchan=10)
+        for sub in subs:
+            wp = sub.to_casa_weightpars()
+            assert 'fracbw' not in wp
+


### PR DESCRIPTION
This pull request improves the configuration and partitioning logic for subcubes in the image processing pipeline, especially for cases where channel start and width values may be specified as either strings or integers (e.g., frequencies or channel indices). It also enhances support for the `briggsbwtaper` weighting scheme by ensuring correct calculation and inheritance of the fractional bandwidth (`fracbw`) for subcubes. Additionally, it fixes issues with CASA rejecting mixed unit types for channel start and width.

Configuration flexibility and correctness:

* Updated the `ImageConfig` model to allow the `start` and `width` fields to be either `str` or `int`, providing flexibility for specifying these values as either channel indices or frequency/velocity strings.
* Modified the `make_subcube_config` method to accept an optional `width` parameter, ensuring that when `start` is given as a frequency string, a matching frequency `width` can be provided to avoid CASA unit mismatches.

Subcube partitioning improvements:

* Enhanced the `_partition_cube_even` function to pre-compute and propagate a frequency-domain channel width (`width`) for subcubes, ensuring compatibility with CASA when using frequency-based `start` values. [[1]](diffhunk://#diff-dc9ce0e1127a1777a3fc39be3566386f78edcc9d9a19bf5795cc3ff045a1841aR376-R423) [[2]](diffhunk://#diff-dc9ce0e1127a1777a3fc39be3566386f78edcc9d9a19bf5795cc3ff045a1841aR434-R444)
* Improved handling for the `briggsbwtaper` weighting scheme by pre-computing the `fracbw` value from the full cube and propagating it to subcubes, preventing errors when subcubes have only one channel.…tart and width parameters